### PR TITLE
Optimize asFallback() allocs

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1189,8 +1189,7 @@ func parseFixed[T string | []byte](v T) (int64, bool) {
 
 func (d Decimal) asFallback() decimal.Decimal {
 	if d.fallback == nil {
-		x := big.NewInt(d.fixed)
-		return decimal.NewFromBigInt(x, -12)
+		return decimal.New(d.fixed, -precision)
 	}
 	return *d.fallback
 }


### PR DESCRIPTION
Calling `asFallback()` when `fallback` is nil can be simplified to avoid any extra allocs than necessary.

Before:
```
BenchmarkAsFallback-10    327989970	       36.52 ns/op	     40 B/op	  2 allocs/op
```
After:
```
BenchmarkAsFallback-10    1000000000	   4.986 ns/op	      0 B/op	  0 allocs/op
```