### PR TITLE
Fix panic in New() with large value and negative exp

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -126,7 +126,7 @@ func New(value int64, exp int32) Decimal {
 			}
 		}
 		// when exp > 7, it would be greater than maxInt
-		if exp <= 6 {
+		if exp >= 0 && exp <= 6 {
 			s := pow10Table[exp]
 			if value >= minInt/s && value <= maxInt/s {
 				return Decimal{fixed: value * pow10Table[precision+exp]}
@@ -1081,7 +1081,6 @@ func (d *NullDecimal) UnmarshalText(text []byte) error {
 
 	d.Valid = true
 	return nil
-
 }
 
 func (d NullDecimal) Value() (driver.Value, error) {

--- a/decimal.go
+++ b/decimal.go
@@ -124,9 +124,7 @@ func New(value int64, exp int32) Decimal {
 			if value >= minInt*s && value <= maxInt*s {
 				return Decimal{fixed: value * pow10Table[precision+exp]}
 			}
-		}
-		// when exp > 7, it would be greater than maxInt
-		if exp >= 0 && exp <= 6 {
+		} else if exp <= 6 { // when exp > 6, it would be greater than maxInt
 			s := pow10Table[exp]
 			if value >= minInt/s && value <= maxInt/s {
 				return Decimal{fixed: value * pow10Table[precision+exp]}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -138,6 +138,18 @@ func TestDecimal(t *testing.T) {
 			shouldEqual(t, x, alpacadecimal.RequireFromString("10000000"))
 			require.False(t, x.IsOptimized())
 		}
+
+		{
+			x := alpacadecimal.New(10_000_000, 0)
+			shouldEqual(t, x, alpacadecimal.RequireFromString("10000000"))
+			require.False(t, x.IsOptimized())
+		}
+
+		{
+			x := alpacadecimal.New(1_000_000_000, -2)
+			shouldEqual(t, x, alpacadecimal.RequireFromString("10000000"))
+			require.False(t, x.IsOptimized())
+		}
 	})
 
 	t.Run("NewFromBigInt", func(t *testing.T) {
@@ -184,7 +196,6 @@ func TestDecimal(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, x.String(), y.String())
-
 	})
 
 	t.Run("NewFromInt", func(t *testing.T) {


### PR DESCRIPTION
I noticed a index out of range panic when calling New() with a large value and negative exp and was able to reproduce it with the added test cases:

```
--- FAIL: TestDecimal (0.00s)
    --- FAIL: TestDecimal/New (0.00s)
panic: runtime error: index out of range [-2] [recovered]
	panic: runtime error: index out of range [-2]

goroutine 49 [running]:
testing.tRunner.func1.2({0x100e5f2e0, 0x140006d5200})
	/opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1529 +0x384
panic({0x100e5f2e0, 0x140006d5200})
	/opt/homebrew/Cellar/go/1.20.4/libexec/src/runtime/panic.go:884 +0x204
github.com/alpacahq/alpacadecimal.New(0x49960284, 0xfffffffe)
	/Users/neal/alpaca/alpacadecimal/decimal.go:138 +0x238
github.com/alpacahq/alpacadecimal_test.TestDecimal.func6(0x0?)
	/Users/neal/alpaca/alpacadecimal/decimal_test.go:150 +0x4c4
testing.tRunner(0x14000883860, 0x1400000c3a8)
	/opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1576 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1629 +0x368
FAIL	github.com/alpacahq/alpacadecimal	0.162s
FAIL
```

Which make sense as we are looking up `pow10Table` with a negative value.