### PR TITLE
Added Marshal/Unmarshal for graphQL

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -2,6 +2,7 @@ package alpacadecimal
 
 import (
 	"database/sql/driver"
+	"io"
 	"math"
 	"math/big"
 	"regexp"
@@ -574,6 +575,11 @@ func (d Decimal) MarshalBinary() (data []byte, err error) {
 	return d.asFallback().MarshalBinary()
 }
 
+func (a Decimal) MarshalGQL(w io.Writer) {
+    j, _ := a.MarshalText()
+	_, _ = w.Write(j)
+}
+
 // optimized:
 func (d Decimal) MarshalJSON() ([]byte, error) {
 	var str string
@@ -954,6 +960,10 @@ func (d *Decimal) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+func (a *Decimal) UnmarshalGQL(v interface{}) error {
+	return a.Scan(v)
+}
+
 // optimized:
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (d *Decimal) UnmarshalJSON(decimalBytes []byte) error {
@@ -1031,6 +1041,12 @@ func NewNullDecimal(d Decimal) NullDecimal {
 	}
 }
 
+func (a NullDecimal) MarshalGQL(w io.Writer) {
+    j, _ := a.MarshalJSON()
+	_, _ = w.Write(j)
+}
+
+
 func (d NullDecimal) MarshalJSON() ([]byte, error) {
 	if !d.Valid {
 		return []byte("null"), nil
@@ -1052,6 +1068,10 @@ func (d *NullDecimal) Scan(value interface{}) error {
 	}
 	d.Valid = true
 	return d.Decimal.Scan(value)
+}
+
+func (a *NullDecimal) UnmarshalGQL(v interface{}) error {
+	return a.Scan(v)
 }
 
 func (d *NullDecimal) UnmarshalJSON(decimalBytes []byte) error {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -651,6 +652,22 @@ func TestDecimal(t *testing.T) {
 		shouldEqual(t, x, y)
 	})
 
+    t.Run("Decimal.MarshalGQL", func(t *testing.T) {
+		{
+			var x alpacadecimal.Decimal
+			err := x.UnmarshalGQL("123.456")
+			require.NoError(t, err)
+			shouldEqual(t, x, alpacadecimal.New(123456, -3))
+		}
+
+		{
+			var x alpacadecimal.Decimal
+			err := x.UnmarshalGQL([]byte("error"))
+			require.Error(t, err)
+			shouldEqual(t, alpacadecimal.Zero, x)
+		}
+    })
+
 	t.Run("Decimal.MarshalJSON", func(t *testing.T) {
 		{
 			var x alpacadecimal.Decimal
@@ -1026,6 +1043,22 @@ func TestDecimal(t *testing.T) {
 		require.NoError(t, err)
 
 		shouldEqual(t, x, y)
+	})
+
+	t.Run("Decimal.UnmarshalGQL", func(t *testing.T) {
+		{
+            var b strings.Builder
+			x := alpacadecimal.NewFromInt(123)
+			x.MarshalGQL(&b)
+            require.Equal(t, "123", b.String())
+		}
+
+		{
+            var b strings.Builder
+			x := alpacadecimal.NewFromInt(123456789)
+			x.MarshalGQL(&b)
+			require.Equal(t, "123456789", b.String())
+		}
 	})
 
 	t.Run("Decimal.UnmarshalJSON", func(t *testing.T) {


### PR DESCRIPTION
In this pull request, I have added two methods to satisfy the `Marshaler` and `Unmarshaler` interfaces in the [gqlgen](https://github.com/99designs/gqlgen) library. These interfaces can be found in the [jsonw.go](https://github.com/99designs/gqlgen/blob/470fca87d3002399fb02e14cf014c3c26755d87b/graphql/jsonw.go) file at lines 26 and 30.

![cat](https://cdn.shopify.com/s/files/1/0331/9182/1447/articles/FELIWAY___June_2020___How_Much_Space_Does_A_Cat_Need-2.webp?v=1667410689&width=1100)