### PR TITLE
Fix unmarshaling fixed value over existing decimal

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -774,6 +774,7 @@ func (d *Decimal) Scan(value interface{}) error {
 		fixed, ok := parseFixed(v)
 		if ok {
 			d.fixed = fixed
+			d.fallback = nil
 			return nil
 		}
 
@@ -781,6 +782,7 @@ func (d *Decimal) Scan(value interface{}) error {
 		fixed, ok := parseFixed(v)
 		if ok {
 			d.fixed = fixed
+			d.fallback = nil
 			return nil
 		}
 	}
@@ -959,6 +961,7 @@ func (d *Decimal) UnmarshalBinary(data []byte) error {
 func (d *Decimal) UnmarshalJSON(decimalBytes []byte) error {
 	if fixed, ok := parseFixed(decimalBytes); ok {
 		d.fixed = fixed
+		d.fallback = nil
 		return nil
 	}
 
@@ -976,6 +979,7 @@ func (d *Decimal) UnmarshalJSON(decimalBytes []byte) error {
 func (d *Decimal) UnmarshalText(text []byte) error {
 	if fixed, ok := parseFixed(text); ok {
 		d.fixed = fixed
+		d.fallback = nil
 		return nil
 	}
 


### PR DESCRIPTION
When unmarshaling to a Decimal value that already has a fallback and the new value can be optimized with a fixed value, the fallback is not reset and thus, the value returned by all the methods continue to being the old fallback value.

Generally for unmarshal methods, a new struct is created or reset in some way so there is no old values leftover. So the change is to set `fallback` to nil in such cases.