### PR TITLE
NO-JIRA: Fix RoundCeil/RoundFloor Examples

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -710,7 +710,7 @@ func (d Decimal) RoundCash(interval uint8) Decimal {
 //	NewFromFloat(545).RoundCeil(-2).String()   // output: "600"
 //	NewFromFloat(500).RoundCeil(-2).String()   // output: "500"
 //	NewFromFloat(1.1001).RoundCeil(2).String() // output: "1.11"
-//	NewFromFloat(-1.454).RoundCeil(1).String() // output: "-1.5"
+//	NewFromFloat(-1.454).RoundCeil(1).String() // output: "-1.4"
 func (d Decimal) RoundCeil(places int32) Decimal {
 	return newFromDecimal(d.asFallback().RoundCeil(places))
 }
@@ -736,7 +736,7 @@ func (d Decimal) RoundDown(places int32) Decimal {
 //	NewFromFloat(545).RoundFloor(-2).String()   // output: "500"
 //	NewFromFloat(-500).RoundFloor(-2).String()   // output: "-500"
 //	NewFromFloat(1.1001).RoundFloor(2).String() // output: "1.1"
-//	NewFromFloat(-1.454).RoundFloor(1).String() // output: "-1.4"
+//	NewFromFloat(-1.454).RoundFloor(1).String() // output: "-1.5"
 func (d Decimal) RoundFloor(places int32) Decimal {
 	return newFromDecimal(d.asFallback().RoundFloor(places))
 }


### PR DESCRIPTION
As reported in https://github.com/shopspring/decimal/issues/347, the examples for the -1.454 case are wrong.