### PR TITLE
feat: Add public NewFromDecimal which outperforms decimal -> string -> alpacadecimal

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -360,3 +360,38 @@ func BenchmarkRound(b *testing.B) {
 		_ = result
 	})
 }
+
+func BenchmarkNewFromDecimal(b *testing.B) {
+	b.Run("alpacadecimal.Decimal.NewFromDecimal", func(b *testing.B) {
+		d := decimal.New(123, -12)
+
+		var result alpacadecimal.Decimal
+
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			result = alpacadecimal.NewFromDecimal(d)
+		}
+		_ = result
+	})
+
+	b.Run("alpacadecimal.Decimal.RequireFromString", func(b *testing.B) {
+		d := decimal.New(123, -12)
+
+		var result alpacadecimal.Decimal
+
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			result = alpacadecimal.RequireFromString(d.String())
+		}
+		_ = result
+	})
+
+	b.Run("alpacadecimal.Decimal.New", func(b *testing.B) {
+		var result alpacadecimal.Decimal
+		for n := 0; n < b.N; n++ {
+			result = alpacadecimal.New(123, -12)
+		}
+		_ = result
+	})
+
+}

--- a/decimal.go
+++ b/decimal.go
@@ -13,15 +13,17 @@ import (
 // currently support 12 precision, this is tunnable,
 // more precision => smaller maxInt
 // less precision => bigger maxInt
-const precision = 12
-const scale = 1e12
-const maxInt int64 = int64(math.MaxInt64) / scale
-const minInt int64 = int64(math.MinInt64) / scale
-const maxIntInFixed int64 = maxInt * scale
-const minIntInFixed int64 = minInt * scale
-const a1000InFixed int64 = 1000 * scale
-const aNeg1000InFixed int64 = -1000 * scale
-const aCentInFixed int64 = scale / 100
+const (
+	precision             = 12
+	scale                 = 1e12
+	maxInt          int64 = int64(math.MaxInt64) / scale
+	minInt          int64 = int64(math.MinInt64) / scale
+	maxIntInFixed   int64 = maxInt * scale
+	minIntInFixed   int64 = minInt * scale
+	a1000InFixed    int64 = 1000 * scale
+	aNeg1000InFixed int64 = -1000 * scale
+	aCentInFixed    int64 = scale / 100
+)
 
 var pow10Table []int64 = []int64{
 	1e0, 1e1, 1e2, 1e3, 1e4,
@@ -38,11 +40,15 @@ var pow10Table []int64 = []int64{
 //	`valueCache[200000] = "1000"`
 //
 // this consumes about 9 MB in memory with pprof check.
-const cacheSize = 200001
-const cacheOffset = 100000
+const (
+	cacheSize   = 200001
+	cacheOffset = 100000
+)
 
-var valueCache [cacheSize]driver.Value
-var stringCache [cacheSize]string
+var (
+	valueCache  [cacheSize]driver.Value
+	stringCache [cacheSize]string
+)
 
 func init() {
 	// init cache
@@ -62,10 +68,12 @@ func init() {
 // mostly due to lack of usage in Alpaca. we should be able to move "fallback" to "optimized" as needed.
 
 // Variables
-var DivisionPrecision = decimal.DivisionPrecision
-var ExpMaxIterations = decimal.ExpMaxIterations
-var MarshalJSONWithoutQuotes = decimal.MarshalJSONWithoutQuotes
-var Zero = Decimal{fixed: 0}
+var (
+	DivisionPrecision        = decimal.DivisionPrecision
+	ExpMaxIterations         = decimal.ExpMaxIterations
+	MarshalJSONWithoutQuotes = decimal.MarshalJSONWithoutQuotes
+	Zero                     = Decimal{fixed: 0}
+)
 
 func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 	if d1.fallback == nil && d2.fallback == nil {
@@ -76,13 +84,13 @@ func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 }
 
 type Decimal struct {
+	// fallback to original decimal.Decimal if necessary
+	fallback *decimal.Decimal
+
 	// represent decimal with 12 precision, 1.23 will have `fixed = 1_230_000_000_000`
 	// max support decimal is 9_223_372.000_000_000_000
 	// min support decimal is -9_223_372.000_000_000_000
 	fixed int64
-
-	// fallback to original decimal.Decimal if necessary
-	fallback *decimal.Decimal
 }
 
 // optimized:

--- a/decimal.go
+++ b/decimal.go
@@ -126,8 +126,8 @@ func Min(first Decimal, rest ...Decimal) Decimal {
 // optimized:
 // New returns a new fixed-point decimal, value * 10 ^ exp.
 func New(value int64, exp int32) Decimal {
-	d, done := tryOptNew(value, exp)
-	if done {
+	d, ok := tryOptNew(value, exp)
+	if ok {
 		return d
 	}
 	return newFromDecimal(decimal.New(value, exp))
@@ -1118,8 +1118,8 @@ func NewFromDecimal(d decimal.Decimal) Decimal {
 	}
 	value := co.Int64()
 	exp := d.Exponent()
-	res, done := tryOptNew(value, exp)
-	if done {
+	res, ok := tryOptNew(value, exp)
+	if ok {
 		return res
 	}
 	return newFromDecimal(d)

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -198,6 +198,22 @@ func TestDecimal(t *testing.T) {
 		require.Equal(t, x.String(), y.String())
 	})
 
+	t.Run("NewFromDecimal", func(t *testing.T) {
+		// first, with optimized decimal
+		x := alpacadecimal.NewFromDecimal(decimal.New(123, -2))
+		y := alpacadecimal.New(123, -2)
+		shouldEqual(t, x, y)
+
+		// the prior means of conversion from decimal commonly used
+		y = alpacadecimal.RequireFromString(decimal.New(123, -2).String())
+		shouldEqual(t, x, y)
+
+		// now, with out of optimization range decimal
+		x = alpacadecimal.NewFromDecimal(decimal.New(123, -13))
+		y = alpacadecimal.New(123, -13)
+		shouldEqual(t, x, y)
+	})
+
 	t.Run("NewFromInt", func(t *testing.T) {
 		x := alpacadecimal.NewFromInt(123)
 		y, err := alpacadecimal.NewFromString("123")


### PR DESCRIPTION
Should close https://github.com/alpacahq/alpacadecimal/issues/7

Note, from my benchmarking:
```
goos: linux
goarch: amd64
pkg: github.com/alpacahq/alpacadecimal
cpu: AMD Ryzen 9 3900XT 12-Core Processor           
BenchmarkNewFromDecimal
BenchmarkNewFromDecimal/alpacadecimal.Decimal.NewFromDecimal
BenchmarkNewFromDecimal/alpacadecimal.Decimal.NewFromDecimal-24         	47093888	        25.64 ns/op
BenchmarkNewFromDecimal/alpacadecimal.Decimal.RequireFromString
BenchmarkNewFromDecimal/alpacadecimal.Decimal.RequireFromString-24      	 5173086	       233.9 ns/op
BenchmarkNewFromDecimal/alpacadecimal.Decimal.New
BenchmarkNewFromDecimal/alpacadecimal.Decimal.New-24                    	507679633	         2.316 ns/op
PASS
```

Where `NewFromDecimal` is the added method, `RequireFromString` implements the conversion method specified as slow in the linked issue, and `New` simply creates the `alpacadecimal.Decimal` in-place (no conversion from `decimal.Decimal`).