### PR TITLE
CRYP-2334: Don't panic on high-precision Truncate

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1013,6 +1013,9 @@ func (d Decimal) Tan() Decimal {
 // Truncate truncates off digits from the number, without rounding.
 func (d Decimal) Truncate(precision int32) Decimal {
 	if d.fallback == nil {
+		if precision >= 12 {
+			return d
+		}
 		s := pow10Table[12-precision]
 		return Decimal{fixed: d.fixed / s * s}
 	}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1052,7 +1052,7 @@ func TestDecimal(t *testing.T) {
 		require.Equal(t, "-1.234", y.Truncate(3).String())
 		require.Equal(t, "-1.234", y.Truncate(4).String())
 
-		for i := int32(0); i < 10; i++ {
+		for i := int32(0); i < 20; i++ {
 			requireCompatible(t, func(input string) (string, string) {
 				x := alpacadecimal.RequireFromString(input).Truncate(i).String()
 				y := decimal.RequireFromString(input).Truncate(i).String()


### PR DESCRIPTION
I've noticed that cryptotokens panics when using this library with:

```go
qty := alpacadecimal.RequireFromString("1")
qty.Truncate(18)
```

Above doesn't work, because using "1" doesn't fallback to shopstring and using precision 18 causes index out of range panic:

```
	/home/runner/go/pkg/mod/github.com/alpacahq/alpacadecimal@v0.0.8/decimal.go:1016 +0xd9
github.com/alpacahq/alpacadecimal.Decimal.Truncate({0x0?, 0x14ba69f?}, 0x1731928?)
	/opt/hostedtoolcache/go/1.24.13/x64/src/runtime/panic.go:792 +0x132
	/opt/hostedtoolcache/go/1.24.13/x64/src/net/http/server.go:1947 +0xbe
goroutine 31979 [running]:
panic serving 10.64.87.212:54861: runtime error: index out of range [-6]
```

This change returns early without truncation when precision is 12 or higher.